### PR TITLE
[FIX] restore answer routes / notices

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -6,8 +6,8 @@ Bundler.require(ENV["RACK_ENV"]) if ENV["RACK_ENV"]
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
 
-require_relative "controllers/attachment"
 require_relative "controllers/answer"
+require_relative "controllers/attachment"
 require_relative "controllers/comment"
 require_relative "controllers/issue"
 require_relative "controllers/member"
@@ -23,6 +23,7 @@ require_relative "db/model"
 class App < Sinatra::Base
   register Sinatra::ActiveRecordExtension
 
+  use AnswerRoutes
   use AttachmentRoutes
   use CommentRoutes
   use IssueRoutes

--- a/db/model.rb
+++ b/db/model.rb
@@ -172,7 +172,6 @@ class Comment < ActiveRecord::Base
 end
 
 class Notice < ActiveRecord::Base
-  validates :name,    presence: true
   validates :title,   presence: true
   validates :text,    presence: true
   validates :pinned, inclusion: { in: [true, false] }


### PR DESCRIPTION
Fix below things
- Answer routes had removed (returned 404)
- Creating / Updating notices returns 500 (missing validation)
